### PR TITLE
fix strftime('%z%Z') of gmtime

### DIFF
--- a/Piece.pm
+++ b/Piece.pm
@@ -447,10 +447,17 @@ sub month_last_day {
     return $MON_LAST[$_mon] + ($_mon == 1 ? _is_leap_year($year) : 0);
 }
 
+my %GMT_REPR = (
+    '%z' => '+0000',
+    '%Z' => 'UTC',
+);
+
 sub strftime {
     my $time = shift;
-    my $tzname = $time->[c_islocal] ? '%Z' : 'UTC';
-    my $format = @_ ? shift(@_) : "%a, %d %b %Y %H:%M:%S $tzname";
+    my $format = @_ ? shift(@_) : '%a, %d %b %Y %H:%M:%S %Z';
+    if (! $time->[c_islocal]) {
+        $format =~ s/(%.)/$GMT_REPR{$1} || $1/eg;
+    }
     if (!defined $time->[c_wday]) {
         if ($time->[c_islocal]) {
             return _strftime($format, CORE::localtime($time->epoch));

--- a/t/02core.t
+++ b/t/02core.t
@@ -1,4 +1,4 @@
-use Test::More tests => 96;
+use Test::More tests => 100;
 
 my $is_win32 = ($^O =~ /Win32/);
 my $is_qnx = ($^O eq 'qnx');
@@ -126,6 +126,11 @@ cmp_ok($t->strftime('%W'), 'eq', '09'); # Sun cmp Mon
 
 cmp_ok($t->strftime('%y'), '==', 0); # should test with 1999
 cmp_ok($t->strftime('%Y'), 'eq', '2000');
+
+cmp_ok($t->strftime('%z'), 'eq', '+0000');
+cmp_ok($t->strftime('%%z%z'), 'eq', '%z+0000');
+cmp_ok($t->strftime('%Z'), 'eq', 'UTC');
+cmp_ok($t->strftime('%%Z%Z'), 'eq', '%ZUTC');
 
 # %Z is locale and implementation dependent
 # (there is NO standard for timezone names)


### PR DESCRIPTION
In my environment, `localtime->strftime('%z %Z')` returns `+0900 JST`, it's OK.

But `gmtime->strftime('%z %Z')` also returns `+0900 JST`, it seems fault.
The right result would be `+0000 UTC` (or `GMT`, `strftime(3)` on Linux represents `GMT` for `gmtime`).
