### PR TITLE
sun compiler doesn't allow extern inline functions to call static inline functions

### DIFF
--- a/Piece.xs
+++ b/Piece.xs
@@ -14,6 +14,8 @@ extern "C" {
 #  define TP_INLINE INLINE /* TP = Time::Piece */
 #elif defined(_MSC_VER)
 #  define TP_INLINE __forceinline /* __inline often doesn't work in O1 */
+#elif defined(__SUNPRO_C)
+#  define TP_INLINE static inline
 #else
 #  define TP_INLINE inline
 #endif


### PR DESCRIPTION
gcc does allow this, and I double checked that the macro I am using is NOT defined in gcc on sun

Here is the error without this patch:

```
sun% make
Skip blib/lib/Time/Seconds.pm (unchanged)
Skip blib/lib/Time/Piece.pm (unchanged)
Running Mkbootstrap for Time::Piece ()
chmod 644 Piece.bs
/home/ollisg/opt/perl/5.16.2/bin/perl /home/ollisg/perl5/5.16.2/lib/perl5/ExtUtils/xsubpp  -typemap /home/ollisg/opt/perl/5.16.2/lib/5.16.2/ExtUtils/typemap  Piece.xs > Piece.xsc && mv Piece.xsc Piece.c
cc -c   -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DPERL_USE_SAFE_PUTENV -O   -DVERSION=\"1.26\" -DXS_VERSION=\"1.26\" -KPIC "-I/home/ollisg/opt/perl/5.16.2/lib/5.16.2/i86pc-solaris/CORE"   Piece.c
"Piece.xs", line 966: reference to static identifier "_strptime" in extern inline function
"Piece.c", line 1309: warning: statement not reached
"Piece.c", line 1347: warning: statement not reached
"Piece.c", line 1392: warning: statement not reached
"Piece.c", line 1433: warning: statement not reached
cc: acomp failed for Piece.c
make: *** [Piece.o] Error 1
```
