### PR TITLE
Make strptime() to check if date string is matching format completely.

### DIFF
--- a/Piece.xs
+++ b/Piece.xs
@@ -455,8 +455,12 @@ _strptime(pTHX_ const char *buf, const char *fmt, struct tm *tm, int *got_GMT)
      */
 	ptr = fmt;
 	while (*ptr != 0) {
-		if (*buf == 0)
-			break;
+		if (*buf == 0) {
+			/* trailing whitespace is allowed */
+			while (isspace((unsigned char)*ptr))
+				ptr++;
+			return (*ptr == 0) ? (char *)buf : 0;
+		}
 
 		c = *ptr++;
 		

--- a/t/02core.t
+++ b/t/02core.t
@@ -1,4 +1,4 @@
-use Test::More tests => 96;
+use Test::More tests => 98;
 
 my $is_win32 = ($^O =~ /Win32/);
 my $is_qnx = ($^O eq 'qnx');
@@ -227,3 +227,16 @@ cmp_ok(
   951827696
 );
 
+eval { Time::Piece->strptime("2014", '%Y%m') };
+like(
+  $@,
+  qr/Error parsing time/,
+  "croak if passed string wasn't enough to match with format"
+);
+
+eval { Time::Piece->strptime("", '%y') };
+like(
+  $@,
+  qr/Error parsing time/,
+  "croak if empty string passed to strptime with non-empty format"
+);


### PR DESCRIPTION
`Time::Piece->strptime()` croaks if first argument `STRING` isn't matching second argument `FORMAT`.  For example, following code will croaked:

``` perl
Time::Piece->strptime("2014-01-01", '%Y/%m/%d'); #=> Error parsing time at ...
```

But there are cases that invalid date string is ignored and Time::Piece object is returned regardless to date string.
### Case1: Not enough date string

Date string and format are compared from ahead and trailing format specifiers are ignored if date string reached end of string while parsing.

``` perl
print Time::Piece->strptime("2014", '%Y-%m'), "\n";
#=> Wed Jan  1 00:00:00 2014
# What about month!?
```
### Case2: Empty date string

Empty date string is ignored even if one or more format has been specified.

``` perl
print Time::Piece->strptime("", '%Y-%m'), "\n";
#=> Thu Jan  1 00:00:00 1970
```

These behavior is differ from unix strptime(3).  Following code can tell us what kind of date string should be treated as invalid:

``` c
#define _XOPEN_SOURCE
#include <stdio.h>
#include <stdlib.h>
#include <time.h>

#define TM_FORMAT "%Y%m"
static const char *const examples[] = {
    "201401",  /* Valid */
    "foo",     /* Invalid */
    "2013",    /* Not enought data */
    "",        /* Empty string */
    "201301 ", /* Trailing whitespaces(allowed) */
    NULL
};

int main(void)
{
    const char *const *ptr = examples;
    struct tm tm;
    int valid;

    while (*ptr != NULL) {
        valid = strptime(*ptr, TM_FORMAT, &tm) != NULL;
        printf("'%s' is %s\n", *ptr, (valid ? "valid" : "invalid"));
        ptr++;
    }

    return 0;
}
```

``` shell
gcc -Wall strptime-checkvalid.c -o strptime-checkvalid
./strptime-checkvalid
'201401' is valid
'foo' is invalid
'2013' is invalid
'' is invalid
'201301 ' is valid
```

We expect that `Time::Piece->strptime()` is respecting unix strptime(3) because you did wrote "see strptime man page." in the POD.
We also expect that every invalid format date string will be notified via croak.
So my opinion is that `Time::Piece->strptime()` should check if date string has completely satisfied format specifier and croak if not.

Regards.
