### PR TITLE
remove unused strings from binary

### DIFF
--- a/Piece.xs
+++ b/Piece.xs
@@ -345,11 +345,12 @@ my_mini_mktime(struct tm *ptm)
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
  
+#define NOID
 #ifndef lint
 #ifndef NOID
-static char copyright[] =
+static const char copyright[] =
 "@(#) Copyright (c) 1994 Powerdog Industries.  All rights reserved.";
-static char sccsid[] = "@(#)strptime.c	0.1 (Powerdog) 94/03/27";
+static const char sccsid[] = "@(#)strptime.c	0.1 (Powerdog) 94/03/27";
 #endif /* !defined NOID */
 #endif /* not lint */
 


### PR DESCRIPTION
On VC2003/win32, these 2 strings were stored in RW memory in the shared
library. They are unused/unreferenced in Time::Piece. Remove them to make
the shared library binary smaller.