### PR TITLE
Clean inheritance

### DIFF
--- a/Piece.pm
+++ b/Piece.pm
@@ -3,12 +3,11 @@ package Time::Piece;
 use strict;
 
 require Exporter;
-require DynaLoader;
 use Time::Seconds;
 use Carp;
 use Time::Local;
 
-our @ISA = qw(Exporter DynaLoader);
+our @ISA = qw(Exporter);
 
 our @EXPORT = qw(
     localtime
@@ -21,7 +20,11 @@ our %EXPORT_TAGS = (
 
 our $VERSION = '1.29_03';
 
-bootstrap Time::Piece $VERSION;
+require DynaLoader;
+{
+    local *dl_load_flags = \&DynaLoader::dl_load_flags;
+    __PACKAGE__->DynaLoader::bootstrap($VERSION);
+}
 
 my $DATE_SEP = '-';
 my $TIME_SEP = ':';

--- a/Piece.pm
+++ b/Piece.pm
@@ -138,7 +138,7 @@ sub import {
         $class->Exporter::export('CORE::GLOBAL', keys %params);
     }
     else {
-        $class->Exporter::export((caller)[0], keys %params);
+        $class->Exporter::export(scalar caller, keys %params);
     }
 }
 

--- a/Piece.pm
+++ b/Piece.pm
@@ -2,12 +2,11 @@ package Time::Piece;
 
 use strict;
 
-require Exporter;
 use Time::Seconds;
 use Carp;
 use Time::Local;
 
-our @ISA = qw(Exporter);
+use Exporter ();
 
 our @EXPORT = qw(
     localtime
@@ -136,10 +135,10 @@ sub import {
     my %params;
     map($params{$_}++,@_,@EXPORT);
     if (delete $params{':override'}) {
-        $class->export('CORE::GLOBAL', keys %params);
+        $class->Exporter::export('CORE::GLOBAL', keys %params);
     }
     else {
-        $class->export((caller)[0], keys %params);
+        $class->Exporter::export((caller)[0], keys %params);
     }
 }
 


### PR DESCRIPTION
Use `Exporter` and `DynaLoader` without inheriting from them.
Because they pollute the namespace of our class.
Because an empty `@ISA` makes methode lookup faster.