### PR TITLE
Improve documentation for add_months and add_years

### DIFF
--- a/Piece.pm
+++ b/Piece.pm
@@ -784,8 +784,8 @@ days, weeks and years in that delta, using the Time::Seconds API.
 In addition to adding seconds, there are two APIs for adding months and
 years:
 
-    $t->add_months(6);
-    $t->add_years(5);
+    $t = $t->add_months(6);
+    $t = $t->add_years(5);
 
 The months and years can be negative for subtractions. Note that there
 is some "strange" behaviour when adding and subtracting months at the


### PR DESCRIPTION
These methods don't act on the time of the object they are called from,
so the previous documentation was open to misinterpretation.

Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=817925