### PR TITLE
Test coverage improvements

### DIFF
--- a/t/02core.t
+++ b/t/02core.t
@@ -1,4 +1,4 @@
-use Test::More tests => 109;
+use Test::More tests => 185;
 
 my $is_win32 = ($^O =~ /Win32/);
 my $is_qnx = ($^O eq 'qnx');
@@ -240,18 +240,82 @@ cmp_ok(
   951827696
 );
 
-#from Time::Piece::Plus
 #test reverse parsing
-my $now = localtime();
-my $strp_format = "%Y-%m-%d %H:%M:%S";
+sub check_parsed {
+    my ($t, $parsed, $t_str, $strp_format) = @_;
 
-my $now_str = $now->strftime($strp_format);
+    cmp_ok($parsed->epoch, '==', $t->epoch,
+        "Epochs match for $t_str with $strp_format");
+    cmp_ok($parsed->strftime($strp_format), 'eq',
+        $t->strftime($strp_format),
+        "Outputs formatted with $strp_format match");
+    cmp_ok($parsed->strftime(), 'eq', $t->strftime(),
+        'Outputs formatted as default match');
+}
 
-my $now_parsed = $now->strptime($now_str, $strp_format);
+for my $time (
+    time(),       # Now, whenever that might be
+    1451606400,   # 2016-01-01 00:00
+    1451649600,   # 2016-01-01 12:00
+) {
+    local $ENV{LC_TIME} = 'en_US'; # Otherwise DD/MM vs MM/DD causes grief
+    my $t = gmtime($time);
+    for my $strp_format (
+        '%Y-%m-%d %H:%M:%S',
+        '%Y-%m-%d %T',
+        '%A, %e %B %Y at %I:%M:%S %p',
+        '%a, %e %b %Y at %r',
+        '%s'
+    ) {
 
-cmp_ok($now_parsed->epoch, '==', $now->epoch);
-cmp_ok($now_parsed->strftime($strp_format), 'eq', $now->strftime($strp_format));
-cmp_ok($now_parsed->strftime(), 'eq', $now->strftime());
+        my $t_str   = $t->strftime($strp_format);
+        my $parsed  = $t->strptime($t_str, $strp_format);
+
+        my $evalres = eval {
+            check_parsed ($t, $parsed, $t_str, $strp_format);
+        };
+        ok(defined $evalres, "Did not die parsing $t with '$strp_format'");
+    }
+    # Formats which cause exceptions to be thrown
+    TODO: for my $strp_format (
+        '%c',
+        '%u %U %Y %T',
+    ) {
+        local $TODO = "strptime does not correctly parse format $strp_format";
+        my $t_str   = $t->strftime($strp_format);
+        my $evalres = eval { my $parsed = $t->strptime($t_str, $strp_format); };
+        ok(defined $evalres, "Did not die parsing $t with '$strp_format'");
+    }
+    # Other bugs
+    TODO: for my $strp_format (
+        #'%s' # Only for localtime because of timezones
+        '%w %W %y %T',
+        #'%x %X', # Can error out for arbitrary times
+    ) {
+        local $TODO = "BUG: format $strp_format parses to wrong time";
+        my $t_str   = $t->strftime($strp_format);
+        my $parsed  = $t->strptime($t_str, $strp_format);
+        check_parsed ($t, $parsed, $t_str, $strp_format);
+    }
+}
+
+TODO: for my $strp_format (
+    '%x %X',
+) {
+    local $TODO  = "BUG: parse format $strp_format expects US dates MM/DD/YY";
+    local $ENV{LC_TIME} = 'en_GB'; # DD/MM/YYYY standard
+    my $time     = 1475402400; # 2016-10-02T10:00:00 day is valid month
+    my $t        = gmtime($time);
+    my $t_str    = $t->strftime($strp_format);
+    my $parsed   = $t->strptime($t_str, $strp_format);
+    check_parsed ($t, $parsed, $t_str, $strp_format);
+
+    $time        = 1476871200; # 2016-10-19T10:00:00 day is not valid month
+    $t           = gmtime($time);
+    $t_str       = $t->strftime($strp_format);
+    my $evalres  = eval { my $parsed = $t->strptime($t_str, $strp_format); };
+    ok(defined $evalres, "Did not die parsing $t with '$strp_format'");
+}
 
 
 my $s = Time::Seconds->new(-691050);

--- a/t/02core.t
+++ b/t/02core.t
@@ -1,4 +1,4 @@
-use Test::More tests => 102;
+use Test::More tests => 109;
 
 my $is_win32 = ($^O =~ /Win32/);
 my $is_qnx = ($^O eq 'qnx');
@@ -143,6 +143,7 @@ cmp_ok($t->date_separator, 'eq', '-');
 
 $t->date_separator("/");
 cmp_ok($t->date_separator, 'eq', '/');
+cmp_ok(Time::Piece::date_separator(), 'eq', '/');
 cmp_ok($t->ymd,            'eq', '2000/02/29');
 
 $t->date_separator("-");
@@ -151,6 +152,7 @@ cmp_ok($t->hms("."),       'eq', '12.34.56');
 
 $t->time_separator(".");
 cmp_ok($t->time_separator, 'eq', '.');
+cmp_ok(Time::Piece::time_separator(), 'eq', '.');
 cmp_ok($t->hms,            'eq', '12.34.56');
 
 $t->time_separator(":");
@@ -170,6 +172,9 @@ $t->day_list(@days);
 
 cmp_ok($t->day, 'eq', "Tue");
 
+my @nmdays = Time::Piece::day_list();
+is_deeply (\@nmdays, \@days);
+
 my @months = $t->mon_list();
 
 my @dumonths = qw(januari februari maart april mei juni
@@ -184,6 +189,8 @@ cmp_ok($t->month, 'eq', "februari");
 $t->mon_list(@months);
 
 cmp_ok($t->month, 'eq', "Feb");
+my @nmmonths = Time::Piece::mon_list();
+is_deeply (\@nmmonths, \@months);
 
 cmp_ok(
   $t->datetime(date => '/', T => ' ', time => '-'),
@@ -249,4 +256,9 @@ cmp_ok($now_parsed->strftime(), 'eq', $now->strftime());
 
 my $s = Time::Seconds->new(-691050);
 is($s->pretty, 'minus 7 days, 23 hours, 57 minutes, 30 seconds');
-
+$s = Time::Seconds->new(10);
+is($s->pretty, '10 seconds');
+$s = Time::Seconds->new(130);
+is($s->pretty, '2 minutes, 10 seconds');
+$s = Time::Seconds->new(7330);
+is($s->pretty, '2 hours, 2 minutes, 10 seconds');

--- a/t/02core_dst.t
+++ b/t/02core_dst.t
@@ -1,4 +1,4 @@
-use Test::More tests => 60;
+use Test::More tests => 61;
 
 my $is_win32 = ($^O =~ /Win32/);
 my $is_qnx = ($^O eq 'qnx');
@@ -125,7 +125,7 @@ cmp_ok($t->month_last_day, '==', 31); # test more
 
 
 SKIP: {
-	skip "Extra tests for Linux, BSD only.", 6 unless $is_linux or $is_mac or $is_bsd;
+	skip "Extra tests for Linux, BSD only.", 7 unless $is_linux or $is_mac or $is_bsd;
 
     local $ENV{TZ} = "EST5EDT4";
     Time::Piece::_tzset();
@@ -138,6 +138,10 @@ SKIP: {
     cmp_ok(scalar($lt->tzoffset), 'eq', '-18000');
     cmp_ok($lt->strftime("%Y-%m-%d %H:%M:%S %Z"), 'eq', '2013-01-09 07:07:11 EST');
     like  ($lt->strftime("%z"), qr/-0500|EST/);
+    TODO: {
+        local $TODO = 'output format "%s" fails to include TZ offset';
+        is    ($lt->strftime("%s"), 1373371631, 'Epoch output is the same');
+    }
 }
 
 

--- a/t/03compare.t
+++ b/t/03compare.t
@@ -1,5 +1,5 @@
-use Test;
-BEGIN { plan tests => 5 }
+use Test::More;
+BEGIN { plan tests => 11 }
 use Time::Piece;
 
 my @t = ('2002-01-01 00:00',
@@ -8,12 +8,18 @@ my @t = ('2002-01-01 00:00',
 @t = map Time::Piece->strptime($_, '%Y-%m-%d %H:%M'), @t;
 
 ok($t[0] < $t[1]);
+ok($t[0] < $t[1]->epoch);
 
 ok($t[0] != $t[1]);
 
 ok($t[0] == $t[0]);
+ok($t[0] == $t[0]->epoch);
 
 ok($t[0] != $t[1]);
 
 ok($t[0] <= $t[1]);
+ok($t[0] <= $t[1]->epoch);
 
+is($t[0] cmp $t[1], -1);
+is($t[1] cmp $t[0],  1);
+is($t[0] cmp $t[0],  0);

--- a/t/07arith.t
+++ b/t/07arith.t
@@ -1,6 +1,6 @@
-use Test::More tests => 25;
+use Test::More tests => 43;
 
-BEGIN { use_ok('Time::Piece'); }
+BEGIN { use_ok('Time::Piece'); use_ok('Time::Seconds'); }
 
 ok(1);
 
@@ -45,3 +45,39 @@ my $t9 = $t->add_months(-13);
 is($t9->year, 2008);
 is($t9->mon, 12);
 is($t9->mday, 1);
+
+eval { $t->add_months(); };
+like($@, qr/add_months requires a number of months/);
+
+# Tests for Time::Seconds start here
+my $s = $t - $t7;
+is($s->minutes, 44640);
+is($s->hours,     744);
+is($s->days,       31);
+is(int($s->weeks),  4);
+is(int($s->months), 1);
+is(int($s->years),  0);
+
+$s2 = $s->copy;
+is($s2->minutes, 44640, 'Copy Time::Seconds object');
+$s2 = $s->copy + 60;
+is($s2->minutes, 44641, 'Add integer to Time::Seconds object');
+$s2 += ONE_HOUR;
+is($s2->minutes, 44701, 'Add exported constant to Time::Seconds object');
+$s2 += $s2;
+is($s2->minutes, 89402, 'Add one Time::Seconds object to another');
+
+$s2 += 300 * ONE_DAY;
+is(int($s2->financial_months), 12);
+is(int($s2->months),           11);
+
+$s2 = Time::Seconds->new();
+is($s2->seconds,  0, 'Empty Time::Seconds constructor is 0s');
+my $s3 = Time::Seconds->new(10);
+$s2 = $s2 + $s3;
+is($s2->seconds, 10, 'Add 2 Time::Seconds objects');
+$s2 -= $s3;
+is($s2->seconds,  0, 'Subtract one Time::Seconds object from another');
+
+eval { $s2 = $s2 + $t; };
+like($@, qr/Can't use non Seconds object in operator overload/);

--- a/t/99legacy.t
+++ b/t/99legacy.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+no warnings 'deprecated';
+
+use Test::More tests => 5;
+
+BEGIN { use_ok('Time::Piece'); }
+
+# The parse() legacy method is deprecated and will not be maintained.
+# The tests in this script illustrate both its functionality and some of
+# its bugs. This script should be removed from the test suite once
+# parse() has been deleted from Time::Piece.
+my $timestring = '2000-01-01T06:00:00';
+my $t1 = Time::Piece->parse ($timestring);
+isnt($t1->datetime, $timestring, 'LEGACY: parse string months fail');
+my $t2 = $t1->parse (0, 0, 6, 1, 0, 100);
+is($t2->datetime, $timestring, 'LEGACY: parse array');
+eval { $t2 = Time::Piece->parse (); };
+is($t2->datetime, $timestring, 'LEGACY: parse with no args dies');
+eval { $t2 = Time::Piece::parse (0, 0, 12, 1, 0, 100); };
+is($t2->datetime, $timestring, 'LEGACY: parse as non-method dies');


### PR DESCRIPTION
In response to issue #26 this PR increases the coverage generally (all perl subs are now covered, even parse()) and also includes a number of tests of strptime for both regression and also TODO tests for these bugs:
- Fatal parse errors for some format strings
- Incorrect times resulting from parsing
- Locale-specific parsing errors (DD/MM vs MM/DD in %x)

There's also one TODO test for what I believe is a bug in that the strftime output with %s (to give epoch time) appears to be timezone dependent.

Note that some of the new tests generate "garbage at end of string in strptime" warnings which might indicate further issues with strptime.

This PR is submitted as part of the [CPAN PR Challenge](http://cpan-prc.org).
