### PR TITLE
Piece.xs: improve strptime %z format

### DIFF
--- a/Piece.xs
+++ b/Piece.xs
@@ -840,7 +840,23 @@ label:
 					i *= 10;
 					i += *buf - '0';
 					buf++;
-				} else
+				}
+				else if (len == 2) {
+					/* for hh:mm */
+					if (*buf == ':') {
+						len += 1;
+						buf++;
+						/* stop at a double colon "hh::..." */
+						if (*buf == ':')
+							break;
+					}
+					/* for hh alone */
+					else {
+						i *= 100;
+						break;
+					}
+				}
+				else
 					return 0;
 			}
 


### PR DESCRIPTION
When parsing %z with strptime, accept a timezone specification of the form [+-]HH or [+-]HH:MM in addition to the current [+-]HHMM. The lattermost is RFC 822, while the former two are from ISO 8601.

--

this was asked about in the libera `#perl` channel a while ago. it seemed simple enough to support.